### PR TITLE
Add AKS RBAC Cluster Admin role for user namespace deployments

### DIFF
--- a/docs/book/src/features/container-assist-azure-resources.md
+++ b/docs/book/src/features/container-assist-azure-resources.md
@@ -12,10 +12,10 @@ Container Assist operates across multiple resource groups and requires both reso
 |------|-------|-------------|-----|
 | **Owner** | Subscription | **Yes** | Has full resource management and role assignment permissions. |
 | **Contributor + User Access Administrator** | Subscription | **Yes** | Contributor handles resource creation; User Access Administrator handles role assignments. |
-| **Contributor** (alone) | Subscription | **No** | Can create resource groups, managed identities, and federated credentials, but **cannot assign RBAC roles**. All 9 role assignments will fail. |
+| **Contributor** (alone) | Subscription | **No** | Can create resource groups, managed identities, and federated credentials, but **cannot assign RBAC roles**. All role assignments will fail. |
 | **Contributor** (alone) | Resource group | **No** | Cannot list clusters/ACRs across the subscription, cannot create the OIDC resource group, and cannot assign roles. |
 
-> **Why Contributor alone is not enough:** The Contributor role explicitly excludes `Microsoft.Authorization/roleAssignments/write`. Container Assist assigns up to 9 RBAC roles across multiple resources (see [Role Assignments](#role-assignments) below). Without role assignment permissions, the OIDC setup completes partially -- the managed identity and federated credential are created, but the pipeline will fail at runtime because the identity lacks access to the cluster and ACR. The extension warns you which roles could not be assigned so you can request them from an admin.
+> **Why Contributor alone is not enough:** The Contributor role explicitly excludes `Microsoft.Authorization/roleAssignments/write`. Container Assist assigns up to 10 RBAC roles across multiple resources (see [Role Assignments](#role-assignments) below). Without role assignment permissions, the OIDC setup completes partially -- the managed identity and federated credential are created, but the pipeline will fail at runtime because the identity lacks access to the cluster and ACR. The extension warns you which roles could not be assigned so you can request them from an admin.
 
 ### Why subscription-level access is needed
 
@@ -24,7 +24,7 @@ Container Assist touches up to 4 separate resource groups during a single run:
 | Resource group | What happens there |
 |---|---|
 | **OIDC identity RG** (e.g. `rg-myapp-oidc`) | Created if it doesn't exist. Managed identity and federated credential are created here. |
-| **AKS cluster RG** | AKS Cluster User Role and AKS RBAC Writer are assigned here. Cluster properties are read. |
+| **AKS cluster RG** | AKS Cluster User Role, AKS RBAC Writer, and AKS RBAC Cluster Admin are assigned here (user namespace path). Cluster properties are read. |
 | **ACR RG** | AcrPull, AcrPush, and ACR Tasks Contributor are assigned here. May be a different RG than the cluster. |
 | **Node RG** (MC_*) | Kubelet identity is read from the cluster object (no direct operations). |
 
@@ -119,9 +119,9 @@ For standard (non-managed) Kubernetes namespaces:
 | 2 | **AcrPush** | `8311e382-0749-4cb8-b61a-304f252e45ec` | ACR resource | Allows the workflow to push built container images to ACR |
 | 3 | **Container Registry Tasks Contributor** | `fb382eab-e894-4461-af04-94435c366c3f` | ACR resource | Allows the workflow to run `az acr build` (cloud-based image builds) |
 | 4 | **Azure Kubernetes Service RBAC Writer** | `a7ffa36f-339b-4b5c-8bdf-e2c188b2c0eb` | AKS cluster resource | Allows the workflow to deploy workloads to the cluster. **Only assigned if Azure RBAC is enabled on the cluster.** |
+| 5 | **Azure Kubernetes Service RBAC Cluster Admin** | `b1ff04bb-8a4e-4dc4-8eb5-8693973ce19b` | AKS cluster resource | Allows the workflow to annotate namespace objects (cluster-scoped resources). **Only assigned if Azure RBAC is enabled on the cluster.** |
 
-> **Note on role #4:** The AKS RBAC Writer role is only assigned when the cluster has Azure RBAC enabled (`aadProfile.enableAzureRBAC`). If the cluster uses Kubernetes-native RBAC instead, this role is skipped and you will need to create a Kubernetes `ClusterRoleBinding` or `RoleBinding` manually.
-
+> **Note on roles #4 and #5:** The AKS RBAC Writer and AKS RBAC Cluster Admin roles are only assigned when the cluster has Azure RBAC enabled (`aadProfile.enableAzureRBAC`). If the cluster uses Kubernetes-native RBAC instead, these roles are skipped and you will need to create a Kubernetes `ClusterRoleBinding` or `RoleBinding` manually. The Cluster Admin role is specifically required because annotating a namespace (`kubectl annotate namespace`) requires patch access on the namespace resource and RBAC Writer role doesn't provide that.
 #### Managed Namespace Path
 
 For AKS managed namespaces, roles are scoped to the specific namespace rather than the entire cluster:

--- a/docs/book/src/features/container-assist-github-workflow.md
+++ b/docs/book/src/features/container-assist-github-workflow.md
@@ -60,7 +60,7 @@ The following values are injected into the workflow template. All deployment-spe
 | 3. Set up kubelogin | `azure/use-kubelogin@v1` | Install kubelogin for non-interactive Azure AD authentication |
 | 4. Get K8s context | `azure/aks-set-context@v4` (user namespace) or `az aks namespace get-credentials` (managed namespace) | Fetch kubeconfig for the target cluster/namespace |
 | 5. Deploy application | `Azure/k8s-deploy@v5` | Apply Kubernetes manifests with the built image |
-| 6. Annotate namespace | `kubectl annotate namespace` | Set `aks-project/workload-identity-id` and `aks-project/workload-identity-tenant` |
+| 6. Annotate namespace | `kubectl annotate namespace` | Set `aks-project/workload-identity-id` and `aks-project/workload-identity-tenant`. Requires the **AKS RBAC Cluster Admin** role because annotating namespace requires patch access on the namespace resource, which is only covered by the Cluster Admin role. |
 | 7. Annotate deployment | `kubectl annotate deployment --all` | Set traceability annotations (see [Deployment Annotations](./container-assist-integration.md#deployment-annotations)) |
 
 ### GitHub Actions Permissions
@@ -145,6 +145,7 @@ The namespace type affects multiple aspects of the generated workflow and OIDC c
 | **Workflow template** | `aks-deploy.template.yaml` | `aks-deploy-managed-ns.template.yaml` |
 | **Kubeconfig method** | `azure/aks-set-context@v4` action | `az aks namespace get-credentials` CLI command + `kubelogin convert-kubeconfig` |
 | **Role scope for K8s access** | Cluster-level (conditional on Azure RBAC) | Namespace-level (always) |
+| **AKS RBAC Cluster Admin** | Assigned at cluster scope (conditional on Azure RBAC) | Not assigned |
 | **AKS Namespace Contributor** | Not assigned | Assigned (needed for namespace-scoped kubeconfig) |
 | **AKS Cluster User Role** | Assigned at resource group level | Not assigned |
 

--- a/docs/book/src/features/container-assist-integration.md
+++ b/docs/book/src/features/container-assist-integration.md
@@ -308,9 +308,9 @@ The warning tells you which roles to assign manually. See [Azure Resources and P
 
 ### Azure RBAC is not enabled on the cluster
 
-When Azure RBAC is disabled on the AKS cluster, the extension skips the **AKS RBAC Writer** role assignment for standard (user) namespaces. This is expected behavior -- the role only applies to clusters with Azure RBAC enabled. ACR-related roles (AcrPush, Container Registry Tasks Contributor) are still assigned regardless.
+When Azure RBAC is disabled on the AKS cluster, the extension skips the **AKS RBAC Writer** and **AKS RBAC Cluster Admin** role assignments for standard (user) namespaces. This is expected behavior -- these roles only apply to clusters with Azure RBAC enabled. ACR-related roles (AcrPush, Container Registry Tasks Contributor) are still assigned regardless. The Cluster Admin role is required for the namespace annotation step (`kubectl annotate namespace`), which needs gives patch access to the namespace.
 
-For managed namespaces, AKS RBAC Writer is always assigned at namespace scope, regardless of the cluster-level Azure RBAC setting.
+For managed namespaces, AKS RBAC Writer is always assigned at namespace scope, regardless of the cluster-level Azure RBAC setting. The Cluster Admin role is not assigned for managed namespaces.
 
 ### Project type not detected
 

--- a/src/commands/aksContainerAssist/oidcSetup.ts
+++ b/src/commands/aksContainerAssist/oidcSetup.ts
@@ -31,6 +31,7 @@ const execFilePromise = promisify(execFile);
 // https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles
 const AKS_CLUSTER_USER_ROLE_ID = "4abbcc35-e782-43d8-92c5-2d3f1bd2253f";
 const AKS_RBAC_WRITER_ROLE_ID = "a7ffa36f-339b-4b5c-8bdf-e2c188b2c0eb";
+const AKS_RBAC_CLUSTER_ADMIN_ROLE_ID = "b1ff04bb-8a4e-4dc4-8eb5-8693973ce19b";
 const AKS_NAMESPACE_CONTRIBUTOR_ROLE_ID = "289d8817-ee69-43f1-a0af-43a45505b488";
 const ACR_PUSH_ROLE_ID = "8311e382-0749-4cb8-b61a-304f252e45ec";
 const ACR_TASKS_CONTRIBUTOR_ROLE_ID = "fb382eab-e894-4461-af04-94435c366c3f";
@@ -632,7 +633,8 @@ async function assignUserNamespaceDeploymentRoles(
         warnings.push(l10n.t("Container Registry Tasks Contributor"));
     }
 
-    // Only assign AKS RBAC Writer at cluster scope when Azure RBAC is enabled on the cluster.
+    // Only assign AKS RBAC Writer and AKS RBAC Cluster Admin at cluster scope when Azure RBAC is enabled on the cluster.
+    // Cluster Admin is required for annotating namespace objects (cluster-scoped resources).
     const azureRbacEnabled = await isAzureRbacEnabledForCluster(
         credential,
         subscriptionId,
@@ -640,17 +642,31 @@ async function assignUserNamespaceDeploymentRoles(
         clusterName,
     );
     if (azureRbacEnabled) {
-        const rbacResult = await createRoleAssignment(
-            authClient,
-            subscriptionId,
-            principalId,
-            AKS_RBAC_WRITER_ROLE_ID,
-            clusterScope,
-            "ServicePrincipal",
-        );
-        if (!rbacResult.succeeded) {
-            logger.warn(`AKS RBAC Writer assignment: ${rbacResult.error}`);
+        const [rbacWriterResult, clusterAdminResult] = await Promise.all([
+            createRoleAssignment(
+                authClient,
+                subscriptionId,
+                principalId,
+                AKS_RBAC_WRITER_ROLE_ID,
+                clusterScope,
+                "ServicePrincipal",
+            ),
+            createRoleAssignment(
+                authClient,
+                subscriptionId,
+                principalId,
+                AKS_RBAC_CLUSTER_ADMIN_ROLE_ID,
+                clusterScope,
+                "ServicePrincipal",
+            ),
+        ]);
+        if (!rbacWriterResult.succeeded) {
+            logger.warn(`AKS RBAC Writer assignment: ${rbacWriterResult.error}`);
             warnings.push(l10n.t("AKS RBAC Writer"));
+        }
+        if (!clusterAdminResult.succeeded) {
+            logger.warn(`AKS RBAC Cluster Admin assignment: ${clusterAdminResult.error}`);
+            warnings.push(l10n.t("AKS RBAC Cluster Admin"));
         }
     }
 


### PR DESCRIPTION
## Summary

- Adds **Azure Kubernetes Service RBAC Cluster Admin** role assignment for user (non-managed) namespaces in `assignUserNamespaceDeploymentRoles`, conditional on Azure RBAC being enabled on the cluster. This is required because `kubectl annotate namespace` operates on a cluster-scoped resource that the existing RBAC Writer role does not cover.
- Managed namespaces are **not** assigned this role — their workflow uses namespace-scoped credentials and does not need cluster-level admin access.
- Updates documentation across 3 doc files to reflect the new role, corrected role count (10 total), and managed vs. user namespace comparison tables.

## Changes

### Code (`oidcSetup.ts`)
- Added `AKS_RBAC_CLUSTER_ADMIN_ROLE_ID` constant (`b1ff04bb-8a4e-4dc4-8eb5-8693973ce19b`)
- Added Cluster Admin role assignment in `assignUserNamespaceDeploymentRoles` (alongside RBAC Writer, gated on `enableAzureRBAC`)
- `assignManagedNamespaceDeploymentRoles` is unchanged — 4 roles only (RBAC Writer, Namespace Contributor, AcrPush, ACR Tasks Contributor)

### Docs
- **container-assist-azure-resources.md**: Updated role count from 11 to 10, added Cluster Admin row to user NS table, removed it from managed NS table, clarified AKS cluster RG description
- **container-assist-github-workflow.md**: Updated managed vs. user comparison table — Cluster Admin is "Not assigned" for managed namespaces
- **container-assist-integration.md**: Updated troubleshooting to clarify Cluster Admin is not assigned for managed namespaces